### PR TITLE
Panic occured when total of argument on command line exceeds those defined in placeholder

### DIFF
--- a/lib/run.go
+++ b/lib/run.go
@@ -84,6 +84,12 @@ func run(name string, inputs ...string) {
 		printlnError("Multiple snippets matched...")
 		os.Exit(1)
 	}
+
+	if len(inputs) > len(snippet.Placeholders) {
+		printlnError("You gave ", len(inputs), " argument(s), limit is ", len(snippet.Placeholders))
+		os.Exit(1)
+	}
+
 	snippet.SetInputs(inputs)
 	dashLineError()
 	if len(inputs) < len(snippet.Placeholders) {


### PR DESCRIPTION
panic: runtime error: index out of range

goroutine 1 [running]:
panic(0x52bee0, 0xc82000e0d0)
        /usr/local/Cellar/go/1.6.2/libexec/src/runtime/panic.go:481 +0x3e6
github.com/tokozedg/sman/lib.(_Snippet).SetInputs(0xc8200c9bb8, 0xc82001a670, 0x3, 0x5)
        /Users/anthony/go/src/github.com/tokozedg/sman/lib/snippet.go:36 +0x112
github.com/tokozedg/sman/lib.run(0x7fff5fbff98d, 0x5, 0xc82001a670, 0x3, 0x5)
        /Users/anthony/go/src/github.com/tokozedg/sman/lib/run.go:88 +0x36a
github.com/tokozedg/sman/lib.glob.func2(0x893ea0, 0xc82001a660, 0x4, 0x6)
        /Users/anthony/go/src/github.com/tokozedg/sman/lib/run.go:136 +0x174
github.com/spf13/cobra.(_Command).execute(0x893ea0, 0xc82001a4e0, 0x6, 0x6, 0x0, 0x0)
        /Users/anthony/go/src/github.com/spf13/cobra/command.go:603 +0x896
github.com/spf13/cobra.(_Command).ExecuteC(0x893c80, 0x893ea0, 0x0, 0x0)
        /Users/anthony/go/src/github.com/spf13/cobra/command.go:689 +0x55c
github.com/spf13/cobra.(_Command).Execute(0x893c80, 0x0, 0x0)
        /Users/anthony/go/src/github.com/spf13/cobra/command.go:648 +0x2d
main.main()
        /Users/anthony/go/src/github.com/tokozedg/sman/main.go:8 +0x23
exit status 2
