### PR TITLE
Respect subtasks in fuzzy search

### DIFF
--- a/lib/fuzzy.go
+++ b/lib/fuzzy.go
@@ -36,12 +36,7 @@ func fSearchFileName(pattern string, dir string) (matched []string) {
 func fSearchSnippet(snippets SnippetSlice, pattern string) (matched SnippetSlice) {
 	topRank := -1
 	for _, s := range snippets {
-		var queries []string
-		if strings.Contains(s.Name, ":") {
-			queries = strings.Split(s.Name, ":")
-		}
-		queries = append(queries, s.Name)
-		for _, part := range queries {
+		for _, part := range nameCombinations(s.Name) {
 			r := fuzzy.RankMatch(pattern, part)
 			switch {
 			case r == -1:
@@ -55,4 +50,32 @@ func fSearchSnippet(snippets SnippetSlice, pattern string) (matched SnippetSlice
 		}
 	}
 	return matched
+}
+
+// construct name combinations using ':' as separator of name parts
+// ex: 1:2:3 -> [1, 2, 3, 1:2, 2:3, 1:2:3]
+func nameCombinations(pattern string) (combinations []string) {
+	if len(pattern) > 0 {
+		if strings.Contains(pattern, ":") {
+			singleNames := strings.Split(pattern, ":")
+
+			// single names
+			combinations = append(combinations, singleNames...)
+
+			// combinations with length 2 to n-1
+			for combLength := 2; combLength < len(singleNames); combLength++ {
+				for startAt := 0; startAt < len(singleNames)-combLength+1; startAt++ {
+					var combination []string
+					for idx := startAt; idx < startAt+combLength; idx++ {
+						combination = append(combination, singleNames[idx])
+					}
+					combinations = append(combinations, strings.Join(combination, ":"))
+				}
+			}
+		}
+
+		// complete name
+		combinations = append(combinations, pattern)
+	}
+	return
 }

--- a/lib/fuzzy.go
+++ b/lib/fuzzy.go
@@ -34,6 +34,13 @@ func fSearchFileName(pattern string, dir string) (matched []string) {
 // fSearchSnippet matches pattern to snippet name in SnippetSlice
 // returns SnippetSlice of best matched snippets.
 func fSearchSnippet(snippets SnippetSlice, pattern string) (matched SnippetSlice) {
+	// special case handling if pattern == snippet name
+	wholeNameMatchTest := func(s Snippet) bool { return s.Name == pattern }
+	wholeNameMatch := snippets.FilterView(wholeNameMatchTest)
+	if wholeNameMatch.Len() == 1 {
+		return wholeNameMatch
+	}
+
 	topRank := -1
 	for _, s := range snippets {
 		for _, part := range nameCombinations(s.Name) {

--- a/lib/fuzzy.go
+++ b/lib/fuzzy.go
@@ -3,6 +3,7 @@ package sman
 import (
 	"github.com/renstrom/fuzzysearch/fuzzy"
 	"sort"
+	"strings"
 )
 
 // topsFromRanks iterates through fuzzy.Ranks and returns results
@@ -31,19 +32,26 @@ func fSearchFileName(pattern string, dir string) (matched []string) {
 }
 
 // fSearchSnippet matches pattern to snippet name in SnippetSlice
-// returnes SnippetSlice of best matched snippets.
+// returns SnippetSlice of best matched snippets.
 func fSearchSnippet(snippets SnippetSlice, pattern string) (matched SnippetSlice) {
 	topRank := -1
 	for _, s := range snippets {
-		r := fuzzy.RankMatch(pattern, s.Name)
-		switch {
-		case r == -1:
-			continue
-		case topRank == -1 || r < topRank:
-			matched = SnippetSlice{s}
-			topRank = r
-		case r == topRank:
-			matched = append(matched, s)
+		var queries []string
+		if strings.Contains(s.Name, ":") {
+			queries = strings.Split(s.Name, ":")
+		}
+		queries = append(queries, s.Name)
+		for _, part := range queries {
+			r := fuzzy.RankMatch(pattern, part)
+			switch {
+			case r == -1:
+				continue
+			case topRank == -1 || r < topRank:
+				matched = SnippetSlice{s}
+				topRank = r
+			case r == topRank:
+				matched = append(matched, s)
+			}
 		}
 	}
 	return matched

--- a/lib/fuzzy_test.go
+++ b/lib/fuzzy_test.go
@@ -95,10 +95,56 @@ func TestFSearchSnippet(t *testing.T) {
 				Snippet{Name: "alias:add"},
 			},
 		},
+		{"multiple matched subtasks partly qualified",
+			SnippetSlice{
+				Snippet{Name: "mysql:user:add"},
+				Snippet{Name: "system:user:add"},
+				Snippet{Name: "alias:add"},
+				Snippet{Name: "non:match"},
+			}, "user:add",
+			SnippetSlice{
+				Snippet{Name: "mysql:user:add"},
+				Snippet{Name: "system:user:add"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		if gotMatched := fSearchSnippet(tt.snippets, tt.pattern); !reflect.DeepEqual(gotMatched, tt.wantMatched) {
 			t.Errorf("%q. fSearchSnippet() = %#v, want %#v", tt.name, gotMatched, tt.wantMatched)
+		}
+	}
+}
+
+func TestNameCombinations(t *testing.T) {
+	tests := []struct {
+		name             string
+		pattern          string
+		wantCombinations []string
+	}{
+		{"empty name",
+			"",
+			[]string(nil),
+		},
+		{"single string",
+			"test",
+			[]string{"test"},
+		},
+		{"one level subtask",
+			"one:two",
+			[]string{"one", "two", "one:two"},
+		},
+		{"two level subtask",
+			"one:two:three",
+			[]string{"one", "two", "three", "one:two", "two:three", "one:two:three"},
+		},
+		{"three level subtask",
+			"one:two:three:four",
+			[]string{"one", "two", "three", "four", "one:two", "two:three", "three:four", "one:two:three", "two:three:four", "one:two:three:four"},
+		},
+	}
+	for _, tt := range tests {
+		if gotCombinations := nameCombinations(tt.pattern); !reflect.DeepEqual(gotCombinations, tt.wantCombinations) {
+			t.Errorf("%q. nameCombinations() = %v, want %v", tt.name, gotCombinations, tt.wantCombinations)
 		}
 	}
 }

--- a/lib/fuzzy_test.go
+++ b/lib/fuzzy_test.go
@@ -107,6 +107,16 @@ func TestFSearchSnippet(t *testing.T) {
 				Snippet{Name: "system:user:add"},
 			},
 		},
+		{"single matched fully qualified special case when whole match applies",
+			SnippetSlice{
+				Snippet{Name: "project:build"},
+				Snippet{Name: "project:build:full"},
+				Snippet{Name: "non:match"},
+			}, "project:build",
+			SnippetSlice{
+				Snippet{Name: "project:build"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		if gotMatched := fSearchSnippet(tt.snippets, tt.pattern); !reflect.DeepEqual(gotMatched, tt.wantMatched) {

--- a/lib/fuzzy_test.go
+++ b/lib/fuzzy_test.go
@@ -64,6 +64,37 @@ func TestFSearchSnippet(t *testing.T) {
 				Snippet{Name: "firbe"},
 			},
 		},
+		{"multiple matched subtasks",
+			SnippetSlice{
+				Snippet{Name: "user:add"},
+				Snippet{Name: "alias:add"},
+				Snippet{Name: "non:match"},
+			}, "add",
+			SnippetSlice{
+				Snippet{Name: "user:add"},
+				Snippet{Name: "alias:add"},
+			},
+		},
+		{"single matched fully qualified",
+			SnippetSlice{
+				Snippet{Name: "user:add"},
+				Snippet{Name: "alias:add"},
+				Snippet{Name: "non:match"},
+			}, "alias:add",
+			SnippetSlice{
+				Snippet{Name: "alias:add"},
+			},
+		},
+		{"single matched fuzzy fully qualified",
+			SnippetSlice{
+				Snippet{Name: "user:add"},
+				Snippet{Name: "alias:add"},
+				Snippet{Name: "non:match"},
+			}, "als:dd",
+			SnippetSlice{
+				Snippet{Name: "alias:add"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		if gotMatched := fSearchSnippet(tt.snippets, tt.pattern); !reflect.DeepEqual(gotMatched, tt.wantMatched) {

--- a/lib/snippet.go
+++ b/lib/snippet.go
@@ -157,3 +157,13 @@ func (s SnippetSlice) Less(a, b int) bool {
 func (s SnippetSlice) Swap(a, b int) {
 	s[a], s[b] = s[b], s[a]
 }
+
+// filter input by test function and return new slice with matched snippets
+func (ss SnippetSlice) FilterView(test func(Snippet) bool) (ret SnippetSlice) {
+	for _, s := range ss {
+		if test(s) {
+			ret = append(ret, s)
+		}
+	}
+	return
+}


### PR DESCRIPTION
I had an issue that can be replayed with the current example snippets: You have the snippets 'alias:add' and 'sshconfig:add' in shell.yml, 'user:add' in mysql.yml and 'vhost:add' in apache.yml. 

If you run 's run add' it promptly runs 'user:add' as it is the nearest match. I think the ':'-separator should be respected and it should recognize all 4 snippets as equal concerning the query for just 'add' and report 'Multiple Snippets matched'.

Great project, btw. It really helps in my day-to-day work. :)