### PR TITLE
Print matched snippets when multiple are found

### DIFF
--- a/lib/ls.go
+++ b/lib/ls.go
@@ -25,9 +25,14 @@ func filterSnippets(p string, slice SnippetSlice) (matched SnippetSlice) {
 func doLs(pattern string) {
 	c := getConfig()
 	snippets := getSnippets(pattern, fileFlag, c.SnippetDir, tagFlag)
+	snippets = filterSnippets(pattern, snippets)
+	doLsSlice(snippets)
+}
+
+func doLsSlice(snippets SnippetSlice) {
+	c := getConfig()
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, 25, 2, 0, ' ', 0)
-	snippets = filterSnippets(pattern, snippets)
 	sort.Sort(snippets)
 	var prevFile string
 	for _, s := range snippets {

--- a/lib/ls.go
+++ b/lib/ls.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"sort"
 	"text/tabwriter"
+	"io"
 )
 
 func filterSnippets(p string, slice SnippetSlice) (matched SnippetSlice) {
@@ -26,13 +27,13 @@ func doLs(pattern string) {
 	c := getConfig()
 	snippets := getSnippets(pattern, fileFlag, c.SnippetDir, tagFlag)
 	snippets = filterSnippets(pattern, snippets)
-	doLsSlice(snippets)
+	doLsSlice(snippets, os.Stdout)
 }
 
-func doLsSlice(snippets SnippetSlice) {
+func doLsSlice(snippets SnippetSlice, output io.Writer) {
 	c := getConfig()
 	w := new(tabwriter.Writer)
-	w.Init(os.Stdout, 25, 2, 0, ' ', 0)
+	w.Init(output, 25, 2, 0, ' ', 0)
 	sort.Sort(snippets)
 	var prevFile string
 	for _, s := range snippets {

--- a/lib/run.go
+++ b/lib/run.go
@@ -82,6 +82,7 @@ func run(name string, inputs ...string) {
 		snippet = matchedSnippets[0]
 	default:
 		printlnError("Multiple snippets matched...")
+		doLsSlice(matchedSnippets)
 		os.Exit(1)
 	}
 

--- a/lib/run.go
+++ b/lib/run.go
@@ -82,7 +82,7 @@ func run(name string, inputs ...string) {
 		snippet = matchedSnippets[0]
 	default:
 		printlnError("Multiple snippets matched...")
-		doLsSlice(matchedSnippets)
+		doLsSlice(matchedSnippets, os.Stderr)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
This uses the ls functionality to print the list of snippets when an ambiguous request is done with run. At first I thought about being interactive and asking the user to select which snippet was meant, but I thought this would be overkill :sweat_smile: 